### PR TITLE
Test upgrading to Ubuntu 22.04 and remove mscgen workaround

### DIFF
--- a/.github/workflows/rsmp_core_3.1.2.yml
+++ b/.github/workflows/rsmp_core_3.1.2.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_core repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core

--- a/.github/workflows/rsmp_core_3.1.2.yml
+++ b/.github/workflows/rsmp_core_3.1.2.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_core repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_core_3.1.2.yml
+++ b/.github/workflows/rsmp_core_3.1.2.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-core:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v3
@@ -37,30 +37,8 @@ jobs:
               imagemagick \
               librsvg2-bin \
               latexmk \
-              graphviz
-    - name: Install dependencies for mscgen
-      run: |
-        sudo apt-get remove nginx
-        sudo apt-get remove libgd3
-        sudo apt-get -y install autoconf flex bison gcc make pkg-config libgd-dev
-    - name: Clone mscgen
-      run: git clone https://github.com/dok-net/mscgen.git
-    - name: Fetch patch for mscgen (fixes issue under Ubuntu 20.04)
-      run: |
-        cp .github/patches/gd.diff mscgen
-        cd mscgen
-        patch -p1 <gd.diff
-    - name: Compile and install mscgen
-      run: |
-        cd mscgen
-        chmod +x autogen.sh
-        chmod +x test/renderercheck.sh
-        ./autogen.sh
-        autoupdate
-        ./configure
-        make
-        make check
-        sudo make install
+              graphviz \
+              mscgen
     - name: Build rsmp_core repository
       run: |
         cd rsmp_core/sphinx

--- a/.github/workflows/rsmp_core_3.1.3.yml
+++ b/.github/workflows/rsmp_core_3.1.3.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_core repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core

--- a/.github/workflows/rsmp_core_3.1.3.yml
+++ b/.github/workflows/rsmp_core_3.1.3.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_core repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_core_3.1.3.yml
+++ b/.github/workflows/rsmp_core_3.1.3.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-core:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v3
@@ -37,30 +37,8 @@ jobs:
               imagemagick \
               librsvg2-bin \
               latexmk \
-              graphviz
-    - name: Install dependencies for mscgen
-      run: |
-        sudo apt-get remove nginx
-        sudo apt-get remove libgd3
-        sudo apt-get -y install autoconf flex bison gcc make pkg-config libgd-dev
-    - name: Clone mscgen
-      run: git clone https://github.com/dok-net/mscgen.git
-    - name: Fetch patch for mscgen (fixes issue under Ubuntu 20.04)
-      run: |
-        cp .github/patches/gd.diff mscgen
-        cd mscgen
-        patch -p1 <gd.diff
-    - name: Compile and install mscgen
-      run: |
-        cd mscgen
-        chmod +x autogen.sh
-        chmod +x test/renderercheck.sh
-        ./autogen.sh
-        autoupdate
-        ./configure
-        make
-        make check
-        sudo make install
+              graphviz \
+              mscgen
     - name: Build rsmp_core repository
       run: |
         cd rsmp_core/sphinx

--- a/.github/workflows/rsmp_core_3.1.4.yml
+++ b/.github/workflows/rsmp_core_3.1.4.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_core repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core

--- a/.github/workflows/rsmp_core_3.1.4.yml
+++ b/.github/workflows/rsmp_core_3.1.4.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with: 
+        ref: main
     - name: Check out rsmp_core repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_core_3.1.4.yml
+++ b/.github/workflows/rsmp_core_3.1.4.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-core:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v3
@@ -37,30 +37,8 @@ jobs:
               imagemagick \
               librsvg2-bin \
               latexmk \
-              graphviz
-    - name: Install dependencies for mscgen
-      run: |
-        sudo apt-get remove nginx
-        sudo apt-get remove libgd3
-        sudo apt-get -y install autoconf flex bison gcc make pkg-config libgd-dev
-    - name: Clone mscgen
-      run: git clone https://github.com/dok-net/mscgen.git
-    - name: Fetch patch for mscgen (fixes issue under Ubuntu 20.04)
-      run: |
-        cp .github/patches/gd.diff mscgen
-        cd mscgen
-        patch -p1 <gd.diff
-    - name: Compile and install mscgen
-      run: |
-        cd mscgen
-        chmod +x autogen.sh
-        chmod +x test/renderercheck.sh
-        ./autogen.sh
-        autoupdate
-        ./configure
-        make
-        make check
-        sudo make install
+              graphviz \
+              mscgen
     - name: Build rsmp_core repository
       run: |
         cd rsmp_core/sphinx

--- a/.github/workflows/rsmp_core_3.1.5.yml
+++ b/.github/workflows/rsmp_core_3.1.5.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_core repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core

--- a/.github/workflows/rsmp_core_3.1.5.yml
+++ b/.github/workflows/rsmp_core_3.1.5.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-core:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v3
@@ -22,29 +22,6 @@ jobs:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core
         ref: v3.1.5
-    - name: Install dependencies for mscgen
-      run: |
-        sudo apt-get remove nginx
-        sudo apt-get remove libgd3
-        sudo apt-get -y install autoconf flex bison gcc make pkg-config libgd-dev
-    - name: Clone mscgen
-      run: git clone https://github.com/dok-net/mscgen.git
-    - name: Fetch patch for mscgen (fixes issue under Ubuntu 20.04)
-      run: |
-        cp .github/patches/gd.diff mscgen
-        cd mscgen
-        patch -p1 <gd.diff
-    - name: Compile and install mscgen
-      run: |
-        cd mscgen
-        chmod +x autogen.sh
-        chmod +x test/renderercheck.sh
-        ./autogen.sh
-        autoupdate
-        ./configure
-        make
-        make check
-        sudo make install
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -57,7 +34,8 @@ jobs:
               imagemagick \
               librsvg2-bin \
               latexmk \
-              graphviz
+              graphviz \
+              mscgen
     - name: Build rsmp_core repository
       run: |
         cd rsmp_core

--- a/.github/workflows/rsmp_core_3.1.5.yml
+++ b/.github/workflows/rsmp_core_3.1.5.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_core repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_core_3.2.1.yml
+++ b/.github/workflows/rsmp_core_3.2.1.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_core repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core

--- a/.github/workflows/rsmp_core_3.2.1.yml
+++ b/.github/workflows/rsmp_core_3.2.1.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_core repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_core_3.2.yml
+++ b/.github/workflows/rsmp_core_3.2.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_core repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_core
         path: rsmp_core

--- a/.github/workflows/rsmp_core_3.2.yml
+++ b/.github/workflows/rsmp_core_3.2.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_core repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.0.15.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.0.15.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_sxl_traffic_lights repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.0.15.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.0.15.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_sxl_traffic_lights repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_sxl_traffic_lights
         path: rsmp_sxl_traffic_lights

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.0.15.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.0.15.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-sxl-tlc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v3
@@ -38,30 +38,8 @@ jobs:
               imagemagick \
               inkscape \
               librsvg2-bin \
-              latexmk
-    - name: Install dependencies for mscgen
-      run: |
-        sudo apt-get remove nginx
-        sudo apt-get remove libgd3
-        sudo apt-get -y install autoconf flex bison gcc make pkg-config libgd-dev
-    - name: Clone mscgen
-      run: git clone https://github.com/dok-net/mscgen.git
-    - name: Fetch patch for mscgen (fixes issue under Ubuntu 20.04)
-      run: |
-        cp .github/patches/gd.diff mscgen
-        cd mscgen
-        patch -p1 <gd.diff
-    - name: Compile and install mscgen
-      run: |
-        cd mscgen
-        chmod +x autogen.sh
-        chmod +x test/renderercheck.sh
-        ./autogen.sh
-        autoupdate
-        ./configure
-        make
-        make check
-        sudo make install
+              latexmk \
+              mscgen
     - name: Build rsmp_sxl_traffic_lights repository
       run: |
         cd rsmp_sxl_traffic_lights

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.1.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.1.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_sxl_traffic_lights repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_sxl_traffic_lights
         path: rsmp_sxl_traffic_lights
@@ -69,13 +70,13 @@ jobs:
     steps:
 
     - name: Check out rsmp_schema repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_schema
         path: rsmp_schema
 
     - name: Check out sxl-tools repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/sxl-tools
         path: sxl-tools

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.1.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.1.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_sxl_traffic_lights repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.2.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.2.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out rsmp_documentation repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      tag: main
     - name: Check out rsmp_sxl_traffic_lights repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_sxl_traffic_lights
         path: rsmp_sxl_traffic_lights
@@ -69,13 +70,13 @@ jobs:
     steps:
 
     - name: Check out rsmp_schema repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/rsmp_schema
         path: rsmp_schema
 
     - name: Check out sxl-tools repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: rsmp-nordic/sxl-tools
         path: sxl-tools

--- a/.github/workflows/rsmp_sxl_traffic_lights-1.2.yml
+++ b/.github/workflows/rsmp_sxl_traffic_lights-1.2.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
     - name: Check out rsmp_documentation repository
       uses: actions/checkout@v4
-      tag: main
+      with:
+        ref: main
     - name: Check out rsmp_sxl_traffic_lights repository
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Newer versions of Ubuntu ships with newer Python which is not compatible with some older sphinx extensions that older versions of core/sxl are using.

Options
- Keep using ubuntu 20.04 with workaround for mscgen
- Modify older core/sxl to not use these older extenstions
- Try to install older python on ubuntu 22.04
- Don't provide online version for older versions.

I think option 2 is to prefer, but that involves creating branches for each version